### PR TITLE
Fix message content length calculation

### DIFF
--- a/koap/src/main/kotlin/Decoder.kt
+++ b/koap/src/main/kotlin/Decoder.kt
@@ -191,16 +191,16 @@ fun ByteArray.decodeTcp(): Message.Tcp {
     // +-+-+-+-+-+-+-+-+
     val code = buffer.readByte()
 
-    // Content
-
-    val content = Buffer()
-    content.write(buffer, length)
-
     // |7 6 5 4 3 2 1 0|7 6 5 4 3 2 1 0|7 6 5 4 3 2 1 0|
     // +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
     // | Token (if any, TKL bytes) ...
     // +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-    val token = if (tkl != 0) content.readNumberOfLength(bytes = tkl) else null
+    val token = if (tkl != 0) buffer.readNumberOfLength(bytes = tkl) else null
+
+    // Content
+
+    val content = Buffer()
+    content.write(buffer, length)
 
     // |7 6 5 4 3 2 1 0|7 6 5 4 3 2 1 0|7 6 5 4 3 2 1 0|7 6 5 4 3 2 1 0|
     // +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+

--- a/koap/src/main/kotlin/Encoder.kt
+++ b/koap/src/main/kotlin/Encoder.kt
@@ -166,8 +166,8 @@ private fun Udp.Type.toInt(): Int = when (this) {
  * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
  * |  Len  |  TKL  | Extended Length (if any, as chosen by Len) ...
  * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
- * |      Code     |
- * +-+-+-+-+-+-+-+-+
+ * |      Code     | Token (if any, TKL bytes) ...
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
  * ```
  *
  * @param message to write the header for

--- a/koap/src/test/kotlin/EncoderTest.kt
+++ b/koap/src/test/kotlin/EncoderTest.kt
@@ -63,7 +63,7 @@ class EncoderTest {
         )
 
         val buffer = Buffer().apply {
-            writeHeader(message, tokenLength = 0, contentLength = UINT32_MAX_EXTENDED_LENGTH)
+            writeHeader(message, contentLength = UINT32_MAX_EXTENDED_LENGTH)
         }
         assertEquals(
             expected = """
@@ -72,6 +72,43 @@ class EncoderTest {
                 01          # Code: 1 (GET)
             """.stripComments(),
             actual = buffer.readByteArray().toHexString()
+        )
+    }
+
+    @Test
+    fun `Empty TCP message`() {
+        val message = Message.Tcp(
+            code = GET,
+            token = null,
+            options = emptyList(),
+            payload = byteArrayOf()
+        )
+
+        assertEquals(
+            expected = """
+                00 # Len: 0, Token length: 0
+                01 # Code: 1 (GET)
+            """.stripComments(),
+            actual = message.encode().toHexString()
+        )
+    }
+
+    @Test
+    fun `TCP message with token value of 1`() {
+        val message = Message.Tcp(
+            code = GET,
+            token = 1,
+            options = emptyList(),
+            payload = byteArrayOf()
+        )
+
+        assertEquals(
+            expected = """
+                01 # Len: 0, Token length: 1
+                01 # Code: 1 (GET)
+                01 # Token: 1
+            """.stripComments(),
+            actual = message.encode().toHexString()
         )
     }
 
@@ -284,11 +321,11 @@ private fun testWriteToken(
     expectedSize: Long,
     expectedHex: String
 ) {
-    val buffer = Buffer()
+    val buffer = Buffer().apply { writeToken(token) }
 
     assertEquals(
         expected = expectedSize,
-        actual = buffer.writeToken(token)
+        actual = buffer.size
     )
 
     assertEquals(


### PR DESCRIPTION
Was improperly counting token as part of the "content". Token is now properly seen as part of the header (the token length is **not** a part of the content length calculation).