### PR TITLE
Fix reading tokens of length 8 (bytes)

### DIFF
--- a/koap/src/main/kotlin/Decoder.kt
+++ b/koap/src/main/kotlin/Decoder.kt
@@ -169,7 +169,7 @@ fun ByteArray.decode(
  * ```
  * val header = encoded.decodeTcpHeader()
  * val content = encoded.copyRange(header.size, encoded.size)
- * val message = encoded.decode(content, offset = 0)
+ * val message = content.decode(content, offset = 0)
  * ```
  */
 fun ByteArray.decode(

--- a/koap/src/main/kotlin/Decoder.kt
+++ b/koap/src/main/kotlin/Decoder.kt
@@ -310,7 +310,7 @@ fun ByteArray.decodeTcpHeader(): Header.Tcp = withReader {
     // +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
     // | Token (if any, TKL bytes) ...
     // +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-    val token = readNumberOfLength(bytes = tkl)
+    val token = readNumberOfLength(tkl)
 
     Header.Tcp(
         size = index,
@@ -456,6 +456,15 @@ private fun Int.toCode(): Message.Code = when (this) {
 /**
  * Reads specified number of [bytes] from [ByteArrayReader] receiver to acquire a number.
  *
+ * | Length in bytes | Read as... |
+ * |----------------:|------------|
+ * | 1               | unsigned   |
+ * | 2               | unsigned   |
+ * | 4               | unsigned   |
+ * | 8               | signed     |
+ *
+ * A length of `0` does not read from the [ByteArrayReader] and simply returns `0L`.
+ *
  * @param bytes (count) to read from [ByteArrayReader] to build number
  * @return value of number
  */
@@ -467,5 +476,6 @@ internal fun ByteArrayReader.readNumberOfLength(
     2 -> readUShort().toLong()
     3 -> readUInt24().toLong()
     4 -> readUInt()
+    8 -> readLong()
     else -> throw IllegalArgumentException("Unsupported number length of $bytes bytes")
 }

--- a/koap/src/test/kotlin/DecoderTest.kt
+++ b/koap/src/test/kotlin/DecoderTest.kt
@@ -10,7 +10,6 @@ import com.juul.koap.Message.Option.UriPath
 import com.juul.koap.Message.Option.UriPort
 import com.juul.koap.Message.Udp.Type.Confirmable
 import com.juul.koap.decode
-import com.juul.koap.decodeUdpHeader
 import com.juul.koap.encode
 import com.juul.koap.readOption
 import com.juul.koap.reader

--- a/koap/src/test/kotlin/DecoderTest.kt
+++ b/koap/src/test/kotlin/DecoderTest.kt
@@ -10,6 +10,7 @@ import com.juul.koap.Message.Option.UriPath
 import com.juul.koap.Message.Option.UriPort
 import com.juul.koap.Message.Udp.Type.Confirmable
 import com.juul.koap.decode
+import com.juul.koap.decodeUdpHeader
 import com.juul.koap.encode
 import com.juul.koap.readOption
 import com.juul.koap.reader
@@ -141,7 +142,7 @@ class DecoderTest {
     }
 
     @Test
-    fun `Decoding TCP message does not read beyond length specified in header`() {
+    fun `Decoding Tcp message does not read beyond length specified in header`() {
         val message = Message.Tcp(
             code = GET,
             token = 0,
@@ -153,6 +154,21 @@ class DecoderTest {
         assertEquals(
             expected = message,
             actual = (message.encode() + extraData).decode()
+        )
+    }
+
+    @Test
+    fun `Can decode token of length 8`() {
+        val message = Message.Tcp(
+            code = GET,
+            token = Long.MAX_VALUE,
+            options = emptyList(),
+            payload = "Hello TCP!".toByteArray()
+        )
+
+        assertEquals(
+            expected = message,
+            actual = message.encode().decode()
         )
     }
 }


### PR DESCRIPTION
#17 introduced a regression whereas a token of length 8-bytes would throw an `IllegalArgumentException`. Was an oversight that despite the RFC not stating a need to read 64-bit numbers, we store the token in a `Long` (since it can be up to 8-bytes in length).