### PR TITLE
Bump Maven publish plugin version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,8 @@ buildscript {
 plugins {
     id 'org.jetbrains.kotlin.jvm' version '1.3.71' apply false
     id 'org.jmailen.kotlinter' version '2.2.0' apply false
-    id 'com.vanniktech.maven.publish' version '0.11.1' apply false
+    id 'com.vanniktech.maven.publish' version '0.13.0' apply false
+    id 'org.jetbrains.dokka' version '1.4.10'
     id 'binary-compatibility-validator' version '0.2.3'
 }
 


### PR DESCRIPTION
Dokka is required by new versions of the `com.vanniktech.maven.publish` plugin.