### PR TITLE
[APD-954] Publish to NPM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,3 +74,9 @@ jobs:
           -Psigning.keyId="${{ secrets.SIGNING_KEY_ID }}"
           -Psigning.password="${{ secrets.SIGNING_PASSWORD }}"
           -Psigning.secretKeyRingFile="$HOME/secring.gpg"
+
+      - name: PublishNPM
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          ./gradlew $GRADLE_ARGS jsBrowserProductionWebpack
+          ./gradlew $GRADLE_ARGS publishNpm -PdryRun=true -Pkotlin.npmjs.auth.token="${{ secrets.MOBILE_GITHUB_PACKAGES_PASSWORD }}"

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,10 @@
 buildscript {
     apply from: rootProject.file('gradle/dependencies.gradle')
 
+    ext {
+        kotlinVersion = '1.4.10'
+    }
+
     repositories {
         jcenter()
     }
@@ -8,10 +12,12 @@ buildscript {
 
 plugins {
     id 'org.jmailen.kotlinter' version '2.2.0' apply false
-    id 'org.jetbrains.kotlin.multiplatform' version '1.4.0' apply false
-    id 'org.jetbrains.kotlin.plugin.serialization' version '1.4.0' apply false
+    id 'org.jetbrains.kotlin.multiplatform' version "$kotlinVersion" apply false
+    id 'org.jetbrains.kotlin.plugin.serialization' version "$kotlinVersion" apply false
     id 'com.vanniktech.maven.publish' version '0.11.1' apply false
     id 'binary-compatibility-validator' version '0.2.3'
+    id 'org.jetbrains.kotlin.js' version "$kotlinVersion" apply false
+    id 'com.moowork.node' version '1.3.1' apply false
 }
 
 subprojects {

--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,6 @@
 buildscript {
     apply from: rootProject.file('gradle/dependencies.gradle')
 
-    ext {
-        kotlinVersion = '1.4.10'
-    }
-
     repositories {
         jcenter()
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=com.juul.koap
-VERSION_NAME=0.0.2
+VERSION_NAME=unspecified
 
 POM_NAME=KoAP
 POM_DESCRIPTION=Kotlin CoAP encoder/decoder.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=com.juul.koap
-VERSION_NAME=unspecified
+VERSION_NAME=0.0.2
 
 POM_NAME=KoAP
 POM_DESCRIPTION=Kotlin CoAP encoder/decoder.

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -1,3 +1,9 @@
+ext {
+    kotlinVersion = '1.4.10'
+    okioVersion = '2.6.0'
+    serializationVersion = '1.0.0-RC'
+}
+
 ext.deps = [
     kotlin: [
         stdlib: "org.jetbrains.kotlin:kotlin-stdlib-common",
@@ -9,9 +15,9 @@ ext.deps = [
         ],
     ],
     serialization: [
-        common: "org.jetbrains.kotlinx:kotlinx-serialization-core:1.0.0-RC"
+        common: "org.jetbrains.kotlinx:kotlinx-serialization-core:$serializationVersion"
     ],
-    okio: "com.squareup.okio:okio-multiplatform:2.6.0",
+    okio: "com.squareup.okio:okio-multiplatform:$okioVersion",
     mockk: "io.mockk:mockk:1.10.0",
     equalsverifier: "nl.jqno.equalsverifier:equalsverifier:3.4",
 ]

--- a/gradle/gitLatestTag.sh
+++ b/gradle/gitLatestTag.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+git tag | grep -E '^[0-9]' | sort -V | tail -1
+

--- a/gradle/npm.gradle
+++ b/gradle/npm.gradle
@@ -66,6 +66,7 @@ task preparePublishNpm(type: Copy) {
     // we must publish output that is transformed by atomicfu
     from(jsLegacy.compilations.main.output.allOutputs) {
         // we really only want the webpack output
+        // TODO: typescript types files
         include "koap.js"
     }
     into npmDeployDir

--- a/gradle/npm.gradle
+++ b/gradle/npm.gradle
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2016-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
+ */
+
+apply plugin: 'com.moowork.node'
+
+def prop(name, defVal) {
+    def value = project.properties[name]
+    if (value == null) return defVal
+    return value
+}
+
+def distTag(version) {
+    def i = version.indexOf('-')
+    if (i > 0) return version.substring(i + 1)
+    return "latest"
+}
+
+def npmTemplateDir = file("$projectDir/npm")
+def npmDeployDir = file("$buildDir/npm")
+
+def authToken = prop("kotlin.npmjs.auth.token", "")
+def dryRun = prop("dryRun", "false")
+
+def jsLegacy = kotlin.targets.hasProperty("jsLegacy")
+        ? kotlin.targets.jsLegacy
+        : kotlin.targets.js
+
+// Note: publish transformed files using dependency on sourceSets.main.output
+task preparePublishNpm(type: Copy) {
+    from(npmTemplateDir) {
+        // Postpone expansion of package.json until we configure version property in build.gradle
+        def copySpec = it
+        afterEvaluate {
+            copySpec.expand(project.properties + [kotlinDependency: "\"kotlin\": \"$kotlinVersion\""])
+        }
+    }
+    // we must publish output that is transformed by atomicfu
+    from(jsLegacy.compilations.main.output.allOutputs)
+    into npmDeployDir
+}
+
+task publishNpm(type: NpmTask, dependsOn: [preparePublishNpm]) {
+    workingDir = npmDeployDir
+  
+    doFirst {
+        def npmDeployTag = distTag(version)
+        def deployArgs = ['publish',
+                          "--@juullabs:registry=https://npm.pkg.github.com/",
+                          "--//npm.pkg.github.com/:_authToken=$authToken",
+                          "--tag=$npmDeployTag"]
+        if (dryRun == "true") {
+            println("$npmDeployDir \$ npm arguments: $deployArgs")
+            args = ['pack']
+        } else {
+            args = deployArgs
+        }
+    }
+}

--- a/gradle/npm.gradle
+++ b/gradle/npm.gradle
@@ -2,6 +2,21 @@
  * Copyright 2016-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license.
  */
 
+// The webpack tasks are configured to output build artifacts to $projectDir/npmdist
+// (configured in build.gradle via js.browser.distribution.directory)
+// This task uses $projectDir/npm/package.json as a template to build the final 
+// $projectDir/npmdist/package.json which can then be published.
+//
+// Test with:
+// ./gradlew clean
+// ./gradlew jsBrowserDevelopmentWebpack
+// ./gradlew publishNpm -P dryRun=true -P npmPublishVersion=0.0.3-test5
+// Publish:
+// ./gradlew clean
+// ./gradlew jsBrowserProductionWebpack
+// ./gradlew publishNpm -P kotlin.npmjs.auth.token=<token>
+
+
 apply plugin: 'com.moowork.node'
 
 def prop(name, defVal) {
@@ -16,11 +31,19 @@ def distTag(version) {
     return "latest"
 }
 
+def getLatestGitTag() {
+    def proc = "gradle/gitLatestTag.sh".execute()
+    def outputStream = new StringBuffer()
+    proc.waitForProcessOutput(outputStream, System.err)
+    return outputStream.toString()
+}
+
 def npmTemplateDir = file("$projectDir/npm")
-def npmDeployDir = file("$buildDir/npm")
+def npmDeployDir = file("$buildDir/npmdist")
 
 def authToken = prop("kotlin.npmjs.auth.token", "")
-def dryRun = prop("dryRun", "false")
+def dryRun = prop("dryRun", "true")
+def npmPublishVersion = prop("npmPublishVersion", getLatestGitTag())
 
 def jsLegacy = kotlin.targets.hasProperty("jsLegacy")
         ? kotlin.targets.jsLegacy
@@ -30,26 +53,35 @@ def jsLegacy = kotlin.targets.hasProperty("jsLegacy")
 task preparePublishNpm(type: Copy) {
     from(npmTemplateDir) {
         // Postpone expansion of package.json until we configure version property in build.gradle
+        include "package.json"
         def copySpec = it
         afterEvaluate {
+            // we are not actually using this...
             copySpec.expand(project.properties + [kotlinDependency: "\"kotlin\": \"$kotlinVersion\""])
         }
     }
+    from(npmTemplateDir) {
+        exclude "package.json"
+    }
     // we must publish output that is transformed by atomicfu
-    from(jsLegacy.compilations.main.output.allOutputs)
+    from(jsLegacy.compilations.main.output.allOutputs) {
+        // we really only want the webpack output
+        include "koap.js"
+    }
     into npmDeployDir
 }
 
 task publishNpm(type: NpmTask, dependsOn: [preparePublishNpm]) {
     workingDir = npmDeployDir
-  
+
     doFirst {
-        def npmDeployTag = distTag(version)
-        def deployArgs = ['publish',
+        def npmDeployTag = distTag(npmPublishVersion)
+        def deployArgs = ['notpublish',
                           "--@juullabs:registry=https://npm.pkg.github.com/",
                           "--//npm.pkg.github.com/:_authToken=$authToken",
-                          "--tag=$npmDeployTag"]
+                          "--tag=$npmDeployTag", "foo: $npmPublishVersion"]
         if (dryRun == "true") {
+            println("")
             println("$npmDeployDir \$ npm arguments: $deployArgs")
             args = ['pack']
         } else {

--- a/koap/build.gradle
+++ b/koap/build.gradle
@@ -39,10 +39,15 @@ kotlin {
         apply plugin: 'kotlinx-serialization'
         apply from: rootProject.file('gradle/npm.gradle')
 
+        //moduleName = "koap-core"
+
         browser {
-            // distribution {
-            //     directory = file("$projectDir/mydist/")
-            // }
+            distribution {
+                directory = file("$buildDir/npmdist/")
+            }
+            webpackTask {
+                // ?
+            }
         }
 
         binaries.executable()

--- a/koap/build.gradle
+++ b/koap/build.gradle
@@ -37,7 +37,15 @@ kotlin {
 
     js {
         apply plugin: 'kotlinx-serialization'
-        browser()
+        apply from: rootProject.file('gradle/npm.gradle')
+
+        browser {
+            // distribution {
+            //     directory = file("$projectDir/mydist/")
+            // }
+        }
+
+        binaries.executable()
     }
 
     sourceSets {

--- a/koap/npm/koap.d.ts
+++ b/koap/npm/koap.d.ts
@@ -1,0 +1,2 @@
+// Manually declare the entire library module for typescript imports
+declare module '@juullabs/koap'

--- a/koap/npm/package.json
+++ b/koap/npm/package.json
@@ -1,8 +1,8 @@
 {
     "name": "@juullabs/koap",
-    "version" : "$version",
+    "version" : "$npmPublishVersion",
     "description" : "Kotlin CoAP encoder/decoder",
-    "main" : "koap-koap.js",
+    "main" : "koap.js",
     "author": "Juullabs",
     "license": "Apache-2.0",
     "homepage": "https://github.com/JuulLabs/koap",
@@ -19,6 +19,6 @@
       "JavaScript"
     ],
     "peerDependencies": {
-      $kotlinDependency
+        "kotlin": "^$kotlinVersion"
     }
   }

--- a/koap/npm/package.json
+++ b/koap/npm/package.json
@@ -1,0 +1,24 @@
+{
+    "name": "@juullabs/koap",
+    "version" : "$version",
+    "description" : "Kotlin CoAP encoder/decoder",
+    "main" : "koap-koap.js",
+    "author": "Juullabs",
+    "license": "Apache-2.0",
+    "homepage": "https://github.com/JuulLabs/koap",
+    "bugs": {
+      "url": "https://github.com/JuulLabs/koap/issues"
+    },
+    "repository": {
+      "type": "git",
+      "url": "git+https://github.com/JuulLabs/koap.git"
+    },
+    "keywords": [
+      "Kotlin",
+      "CoAP",
+      "JavaScript"
+    ],
+    "peerDependencies": {
+      $kotlinDependency
+    }
+  }

--- a/koap/webpack.config.d/config.js
+++ b/koap/webpack.config.d/config.js
@@ -1,0 +1,1 @@
+// Customize webpack config here


### PR DESCRIPTION
Adds a new `publishNpm ` Gradle task (from npm.gradle) based mostly on one borrowed from the coroutines repo with some hackage.

This task expects the Webpack output from `jsBrowserProductionWebpack` task to already exist.

The `publishNpm` task creates the `npmdist` output folder, copies in the Webpack artifacts, and uses `<module>/npm/package.json` as a template to create a new `package.json` file. It then runs the npm publish command from this folder which publishes the package on GitHub in the `@Juullabs` scope.

When reviewing please provide guidance on best practices on the Gradle stuff. Thus far the effort has been just getting it to work and it would be nice to apply some polish to any areas that are crunchy.

*WIP: Currently specifies `dryRun=true` and a deliberate syntax error (`notpublish` instead of `publish`) to avoid spamming public packages while testing*

