### PR TITLE
Remove global disabling of ktlint no-multi-spaces rule

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ buildscript {
 
 plugins {
     kotlin("multiplatform") version "1.4.10" apply false
-    id("org.jmailen.kotlinter") version "2.2.0" apply false
+    id("org.jmailen.kotlinter") version "3.2.0" apply false
     id("com.vanniktech.maven.publish") version "0.13.0" apply false
     id("org.jetbrains.dokka") version "1.4.10"
     id("binary-compatibility-validator") version "0.2.3"

--- a/koap/build.gradle.kts
+++ b/koap/build.gradle.kts
@@ -7,10 +7,6 @@ plugins {
     id("lt.petuska.npm.publish")
 }
 
-kotlinter {
-    disabledRules = arrayOf("no-multi-spaces")
-}
-
 tasks.withType<JacocoReport> {
     reports {
         csv.isEnabled = false

--- a/koap/src/commonMain/kotlin/Decoder.kt
+++ b/koap/src/commonMain/kotlin/Decoder.kt
@@ -292,6 +292,7 @@ fun ByteArray.decodeTcpHeader(): Header.Tcp = withReader {
     // +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
     // | Extended Length (if any, as chosen by Len) ...
     // +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    /* ktlint-disable no-multi-spaces */
     val length = when (len) {
         in 0..12 -> len.toLong()            // No Extended Length
         13 -> (readUByte() + 13).toLong()   //  8-bit unsigned integer
@@ -299,6 +300,7 @@ fun ByteArray.decodeTcpHeader(): Header.Tcp = withReader {
         15 -> readUInt() + 65805            // 32-bit unsigned integer
         else -> error("Invalid length $len")
     }
+    /* ktlint-enable no-multi-spaces */
 
     // |7 6 5 4 3 2 1 0|
     // +-+-+-+-+-+-+-+-+
@@ -368,23 +370,27 @@ internal fun ByteArrayReader.readOption(preceding: Format?): Option? {
     // /         Option Delta          /   0-2 bytes
     // \          (extended)           \
     // +-------------------------------+
+    /* ktlint-disable no-multi-spaces */
     val delta = when (optionDelta) {
         in 0..12 -> optionDelta  // No Extended Delta
         13 -> readUByte() + 13   //  8-bit unsigned integer
         14 -> readUShort() + 269 // 16-bit unsigned integer
         else -> error("Invalid option delta $optionDelta")
     }
+    /* ktlint-enable no-multi-spaces */
 
     // +-------------------------------+
     // /         Option Length         /   0-2 bytes
     // \          (extended)           \
     // +-------------------------------+
+    /* ktlint-disable no-multi-spaces */
     val length = when (optionLength) {
         in 0..12 -> optionLength // No Extended Length
         13 -> readUByte() + 13   //  8-bit unsigned integer
         14 -> readUShort() + 269 // 16-bit unsigned integer
         else -> error("Invalid option length $optionLength")
     }
+    /* ktlint-enable no-multi-spaces */
 
     return when (val number = (preceding?.number ?: 0) + delta) {
         1 -> IfMatch(readByteArray(length))
@@ -417,6 +423,7 @@ private fun Int.toType(): Message.Udp.Type = when (this) {
     else -> error("Unknown message type: $this")
 }
 
+/* ktlint-disable no-multi-spaces */
 private fun Int.toCode(): Message.Code = when (this) {
     1 -> GET    // 0.01
     2 -> POST   // 0.02
@@ -452,6 +459,7 @@ private fun Int.toCode(): Message.Code = when (this) {
         Message.Code.Raw(`class`, detail)
     }
 }
+/* ktlint-enable no-multi-spaces */
 
 /**
  * Reads specified number of [bytes] from [ByteArrayReader] receiver to acquire a number.

--- a/koap/src/commonMain/kotlin/Encoder.kt
+++ b/koap/src/commonMain/kotlin/Encoder.kt
@@ -171,12 +171,14 @@ internal fun BufferedSink.writeHeader(
         "Token length of $tokenLength is outside allowable range of $UINT4_RANGE"
     }
 
+    /* ktlint-disable no-multi-spaces */
     val len = when {
         contentLength < 13 -> contentLength // No Extended Length
         contentLength < 269 -> 13           // Reserved, indicates  8-bit unsigned integer Extended Length
         contentLength < 65805 -> 14         // Reserved, indicates 16-bit unsigned integer Extended Length
         else -> 15                          // Reserved, indicates 32-bit unsigned integer Extended Length
     }.toInt()
+    /* ktlint-enable no-multi-spaces */
     val tkl = tokenLength.toInt()
 
     // |7 6 5 4 3 2 1 0|
@@ -186,6 +188,7 @@ internal fun BufferedSink.writeHeader(
     writeByte((len shl 4) or tkl)
 
     // Extended Length (if any, as chosen by Len) ...
+    /* ktlint-disable no-multi-spaces */
     when (len) {
         // |7 6 5 4 3 2 1 0|
         // +-+-+-+-+-+-+-+-+
@@ -205,6 +208,7 @@ internal fun BufferedSink.writeHeader(
         // +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
         15 -> writeInt(contentLength - 65805) // 32-bit unsigned integer
     }
+    /* ktlint-enable no-multi-spaces */
 
     // |7 6 5 4 3 2 1 0|
     // +-+-+-+-+-+-+-+-+
@@ -248,12 +252,14 @@ private fun BufferedSink.writeOptions(options: List<Option>) {
  */
 internal fun BufferedSink.writeOption(option: Format, preceding: Format?) {
     val delta = option.number - (preceding?.number ?: 0)
+    /* ktlint-disable no-multi-spaces */
     val optionDelta = when {
         delta in 0..12 -> delta // No Option Delta (extended)
         delta < 269 -> 13       // Reserved, indicates  8-bit unsigned integer Option Delta (extended)
         delta < 65805 -> 14     // Reserved, indicates 16-bit unsigned integer Option Delta (extended)
         else -> error("Invalid option delta $delta")
     }
+    /* ktlint-enable no-multi-spaces */
 
     val optionValue = Buffer().apply {
         when (option) {
@@ -277,6 +283,8 @@ internal fun BufferedSink.writeOption(option: Format, preceding: Format?) {
             is string -> writeUtf8(option.value)
         }
     }
+
+    /* ktlint-disable no-multi-spaces */
 
     val length = optionValue.size.toInt()
     val optionLength = when {
@@ -316,6 +324,8 @@ internal fun BufferedSink.writeOption(option: Format, preceding: Format?) {
     // \                               \
     // +-------------------------------+
     writeAll(optionValue)
+
+    /* ktlint-enable no-multi-spaces */
 }
 
 /**

--- a/koap/src/commonMain/kotlin/Message.kt
+++ b/koap/src/commonMain/kotlin/Message.kt
@@ -1,3 +1,6 @@
+// ktlint-disable indent
+// todo: Disable above rule only on effected line when https://github.com/pinterest/ktlint/issues/631 is fixed.
+
 package com.juul.koap
 
 import com.juul.koap.Message.Option.Observe.Registration.Deregister
@@ -184,6 +187,7 @@ sealed class Message {
             }
 
             /** RFC 7252 12.3. CoAP Content-Formats Registry */
+            /* ktlint-disable no-multi-spaces */
             companion object {
                 val PlainText = ContentFormat(0)    // text/plain; charset=utf-8
                 val LinkFormat = ContentFormat(40)  // application/link-format
@@ -195,6 +199,7 @@ sealed class Message {
                 /** RFC 7049 7.4. CoAP Content-Format */
                 val CBOR = ContentFormat(60)        // application/cbor
             }
+            /* ktlint-enable no-multi-spaces */
         }
 
         /** RFC 7252 5.10.4. Accept */
@@ -330,10 +335,12 @@ sealed class Message {
             override val `class`: Int,
             override val detail: Int
         ) : Code() {
+            /* ktlint-disable no-multi-spaces */
             object GET : Method(`class` = 0, detail = 1)    // 0.01
             object POST : Method(`class` = 0, detail = 2)   // 0.02
             object PUT : Method(`class` = 0, detail = 3)    // 0.03
             object DELETE : Method(`class` = 0, detail = 4) // 0.04
+            /* ktlint-enable no-multi-spaces */
 
             override fun toString(): String = this::class.simpleName!!
         }
@@ -343,6 +350,7 @@ sealed class Message {
             override val `class`: Int,
             override val detail: Int
         ) : Code() {
+            /* ktlint-disable no-multi-spaces */
             object Created : Response(`class` = 2, detail = 1)                   // 2.01
             object Deleted : Response(`class` = 2, detail = 2)                   // 2.02
             object Valid : Response(`class` = 2, detail = 3)                     // 2.03
@@ -364,6 +372,7 @@ sealed class Message {
             object ServiceUnavailable : Response(`class` = 5, detail = 3)        // 5.03
             object GatewayTimeout : Response(`class` = 5, detail = 4)            // 5.04
             object ProxyingNotSupported : Response(`class` = 5, detail = 5)      // 5.05
+            /* ktlint-enable no-multi-spaces */
 
             override fun toString(): String = this::class.simpleName!!
         }
@@ -398,7 +407,7 @@ sealed class Message {
 
         override fun equals(other: Any?): Boolean =
             this === other ||
-                (other is Udp &&
+                (other is Udp && // ktlint-disable indent
                     type == other.type &&
                     code == other.code &&
                     id == other.id &&

--- a/koap/src/commonTest/kotlin/DecoderTest.kt
+++ b/koap/src/commonTest/kotlin/DecoderTest.kt
@@ -13,9 +13,9 @@ import com.juul.koap.decode
 import com.juul.koap.encode
 import com.juul.koap.readOption
 import com.juul.koap.reader
+import okio.ByteString.Companion.decodeHex
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import okio.ByteString.Companion.decodeHex
 
 @ExperimentalStdlibApi // for `encodeToByteArray`
 class DecoderTest {

--- a/koap/src/commonTest/kotlin/EncoderTest.kt
+++ b/koap/src/commonTest/kotlin/EncoderTest.kt
@@ -20,10 +20,10 @@ import com.juul.koap.toHexString
 import com.juul.koap.writeHeader
 import com.juul.koap.writeOption
 import com.juul.koap.writeToken
+import okio.Buffer
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
-import okio.Buffer
 
 @ExperimentalStdlibApi // for `encodeToByteArray`
 class EncoderTest {

--- a/koap/src/jvmTest/kotlin/JvmMessageTest.kt
+++ b/koap/src/jvmTest/kotlin/JvmMessageTest.kt
@@ -4,8 +4,8 @@ import com.juul.koap.Message
 import com.juul.koap.Message.Option.ETag
 import com.juul.koap.Message.Option.Format.opaque
 import com.juul.koap.Message.Option.IfMatch
-import kotlin.test.Test
 import nl.jqno.equalsverifier.EqualsVerifier
+import kotlin.test.Test
 
 class JvmMessageTest {
 


### PR DESCRIPTION
Rather than globally disable `no-multi-spaces` rule, now disabling inline so that we can still get valid warnings elsewhere when that rule is violated.

Also updated kotlinter version as previous version was not compatible with multiplatform (i.e. was not actually running); as a result, some import ordering was updated.