### PR TITLE
APD-957: Add JsExport Annotations

### DIFF
--- a/koap/api/koap.api
+++ b/koap/api/koap.api
@@ -357,11 +357,15 @@ public final class com/juul/koap/Message$Option$Observe : com/juul/koap/Message$
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class com/juul/koap/Message$Option$Observe$Registration : java/lang/Enum {
-	public static final field Deregister Lcom/juul/koap/Message$Option$Observe$Registration;
-	public static final field Register Lcom/juul/koap/Message$Option$Observe$Registration;
-	public static fun valueOf (Ljava/lang/String;)Lcom/juul/koap/Message$Option$Observe$Registration;
-	public static fun values ()[Lcom/juul/koap/Message$Option$Observe$Registration;
+public abstract class com/juul/koap/Message$Option$Observe$Registration {
+}
+
+public final class com/juul/koap/Message$Option$Observe$Registration$Deregister : com/juul/koap/Message$Option$Observe$Registration {
+	public static final field INSTANCE Lcom/juul/koap/Message$Option$Observe$Registration$Deregister;
+}
+
+public final class com/juul/koap/Message$Option$Observe$Registration$Register : com/juul/koap/Message$Option$Observe$Registration {
+	public static final field INSTANCE Lcom/juul/koap/Message$Option$Observe$Registration$Register;
 }
 
 public final class com/juul/koap/Message$Option$ProxyScheme : com/juul/koap/Message$Option {
@@ -479,13 +483,23 @@ public final class com/juul/koap/Message$Udp : com/juul/koap/Message {
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class com/juul/koap/Message$Udp$Type : java/lang/Enum {
-	public static final field Acknowledgement Lcom/juul/koap/Message$Udp$Type;
-	public static final field Confirmable Lcom/juul/koap/Message$Udp$Type;
-	public static final field NonConfirmable Lcom/juul/koap/Message$Udp$Type;
-	public static final field Reset Lcom/juul/koap/Message$Udp$Type;
-	public static fun valueOf (Ljava/lang/String;)Lcom/juul/koap/Message$Udp$Type;
-	public static fun values ()[Lcom/juul/koap/Message$Udp$Type;
+public abstract class com/juul/koap/Message$Udp$Type {
+}
+
+public final class com/juul/koap/Message$Udp$Type$Acknowledgement : com/juul/koap/Message$Udp$Type {
+	public static final field INSTANCE Lcom/juul/koap/Message$Udp$Type$Acknowledgement;
+}
+
+public final class com/juul/koap/Message$Udp$Type$Confirmable : com/juul/koap/Message$Udp$Type {
+	public static final field INSTANCE Lcom/juul/koap/Message$Udp$Type$Confirmable;
+}
+
+public final class com/juul/koap/Message$Udp$Type$NonConfirmable : com/juul/koap/Message$Udp$Type {
+	public static final field INSTANCE Lcom/juul/koap/Message$Udp$Type$NonConfirmable;
+}
+
+public final class com/juul/koap/Message$Udp$Type$Reset : com/juul/koap/Message$Udp$Type {
+	public static final field INSTANCE Lcom/juul/koap/Message$Udp$Type$Reset;
 }
 
 public final class com/juul/koap/MessageKt {

--- a/koap/src/commonMain/kotlin/Decoder.kt
+++ b/koap/src/commonMain/kotlin/Decoder.kt
@@ -47,6 +47,8 @@ import com.juul.koap.Message.Udp.Type.Acknowledgement
 import com.juul.koap.Message.Udp.Type.Confirmable
 import com.juul.koap.Message.Udp.Type.NonConfirmable
 import com.juul.koap.Message.Udp.Type.Reset
+import kotlin.js.JsExport
+import kotlin.js.JsName
 import okio.BufferedSource
 
 /**
@@ -97,6 +99,7 @@ inline fun <reified T : Message> ByteArray.decode(): T =
  * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
  * ```
  */
+@JsExport
 fun ByteArray.decodeUdp(): Message.Udp {
     val header = decodeUdpHeader()
     return decode(header, offset = header.size)
@@ -120,6 +123,7 @@ fun ByteArray.decodeUdp(): Message.Udp {
  * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
  * ```
  */
+@JsExport
 fun ByteArray.decodeTcp(): Message.Tcp {
     val header = decodeTcpHeader()
     return decode(header, offset = header.size)
@@ -146,6 +150,8 @@ fun ByteArray.decodeTcp(): Message.Tcp {
  * val message = encoded.decode(content, offset = 0)
  * ```
  */
+@JsExport
+@JsName("decodeWithUdpHeader")
 fun ByteArray.decode(
     header: Header.Udp,
     offset: Int = header.size
@@ -172,6 +178,8 @@ fun ByteArray.decode(
  * val message = content.decode(content, offset = 0)
  * ```
  */
+@JsExport
+@JsName("decodeWithTcpHeader")
 fun ByteArray.decode(
     header: Header.Tcp,
     offset: Int = header.size
@@ -229,6 +237,7 @@ private fun ByteArray.decodeContent(
  * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
  * ```
  */
+@JsExport
 fun ByteArray.decodeUdpHeader(): Header.Udp = withReader {
     // |7 6 5 4 3 2 1 0|
     // +-+-+-+-+-+-+-+-+
@@ -279,6 +288,7 @@ fun ByteArray.decodeUdpHeader(): Header.Udp = withReader {
  * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
  * ```
  */
+@JsExport
 fun ByteArray.decodeTcpHeader(): Header.Tcp = withReader {
     // |7 6 5 4 3 2 1 0|
     // +-+-+-+-+-+-+-+-+

--- a/koap/src/commonMain/kotlin/Decoder.kt
+++ b/koap/src/commonMain/kotlin/Decoder.kt
@@ -47,9 +47,9 @@ import com.juul.koap.Message.Udp.Type.Acknowledgement
 import com.juul.koap.Message.Udp.Type.Confirmable
 import com.juul.koap.Message.Udp.Type.NonConfirmable
 import com.juul.koap.Message.Udp.Type.Reset
+import okio.BufferedSource
 import kotlin.js.JsExport
 import kotlin.js.JsName
-import okio.BufferedSource
 
 /**
  * Decodes [ByteArray] receiver to a [Message].

--- a/koap/src/commonMain/kotlin/Encoder.kt
+++ b/koap/src/commonMain/kotlin/Encoder.kt
@@ -13,10 +13,9 @@ import com.juul.koap.Message.Udp.Type.Acknowledgement
 import com.juul.koap.Message.Udp.Type.Confirmable
 import com.juul.koap.Message.Udp.Type.NonConfirmable
 import com.juul.koap.Message.Udp.Type.Reset
-import kotlin.js.JsExport
-import kotlin.js.JsName
 import okio.Buffer
 import okio.BufferedSink
+import kotlin.js.JsExport
 
 internal const val UINT32_MAX_EXTENDED_LENGTH = UINT_MAX_VALUE + 65805L
 

--- a/koap/src/commonMain/kotlin/Encoder.kt
+++ b/koap/src/commonMain/kotlin/Encoder.kt
@@ -1,3 +1,4 @@
+@file:JsExport
 package com.juul.koap
 
 import com.juul.koap.Message.Option
@@ -12,6 +13,8 @@ import com.juul.koap.Message.Udp.Type.Acknowledgement
 import com.juul.koap.Message.Udp.Type.Confirmable
 import com.juul.koap.Message.Udp.Type.NonConfirmable
 import com.juul.koap.Message.Udp.Type.Reset
+import kotlin.js.JsExport
+import kotlin.js.JsName
 import okio.Buffer
 import okio.BufferedSink
 

--- a/koap/src/commonMain/kotlin/Encoder.kt
+++ b/koap/src/commonMain/kotlin/Encoder.kt
@@ -1,4 +1,5 @@
 @file:JsExport
+
 package com.juul.koap
 
 import com.juul.koap.Message.Option

--- a/koap/src/commonMain/kotlin/Header.kt
+++ b/koap/src/commonMain/kotlin/Header.kt
@@ -1,4 +1,5 @@
 @file:JsExport
+
 package com.juul.koap
 
 import com.juul.koap.Message.Code

--- a/koap/src/commonMain/kotlin/Header.kt
+++ b/koap/src/commonMain/kotlin/Header.kt
@@ -1,7 +1,9 @@
+@file:JsExport
 package com.juul.koap
 
 import com.juul.koap.Message.Code
 import com.juul.koap.Message.Udp.Type
+import kotlin.js.JsExport
 
 sealed class Header {
 

--- a/koap/src/commonMain/kotlin/Message.kt
+++ b/koap/src/commonMain/kotlin/Message.kt
@@ -3,6 +3,8 @@
 
 package com.juul.koap
 
+import com.juul.koap.Message.Option.Observe.Registration.Deregister
+import com.juul.koap.Message.Option.Observe.Registration.Register
 import kotlin.js.JsExport
 import kotlin.js.JsName
 
@@ -206,7 +208,7 @@ sealed class Message {
         /** RFC 7252 5.10.4. Accept */
         data class Accept(val format: Long) : Option() {
 
-            @JsName("constructorWithContentFormat")
+            @JsName("fromContentFormat")
             constructor(format: ContentFormat) : this(format.format)
 
             init {
@@ -308,11 +310,11 @@ sealed class Message {
              *
              * @see Registration
              */
-            @JsName("constructorWithRegistration")
+            @JsName("fromRegistration")
             constructor(action: Registration) : this(
                 when (action) {
-                    Message.Option.Observe.Registration.Register -> 0L
-                    Message.Option.Observe.Registration.Deregister -> 1L
+                    Register -> 0L
+                    Deregister -> 1L
                 }
             )
 
@@ -404,7 +406,7 @@ sealed class Message {
         override val payload: ByteArray
     ) : Message() {
 
-        sealed class Type() {
+        sealed class Type {
             object Confirmable : Type()
             object NonConfirmable : Type()
             object Acknowledgement : Type()

--- a/koap/src/commonMain/kotlin/Message.kt
+++ b/koap/src/commonMain/kotlin/Message.kt
@@ -299,8 +299,8 @@ sealed class Message {
              * - `1` (deregister) removes the entry from the list, if present.
              */
             sealed class Registration {
-                object Register: Registration()
-                object Deregister: Registration()
+                object Register : Registration()
+                object Deregister : Registration()
             }
 
             /**
@@ -405,10 +405,10 @@ sealed class Message {
     ) : Message() {
 
         sealed class Type() {
-            object Confirmable: Type()
-            object NonConfirmable: Type()
-            object Acknowledgement: Type()
-            object Reset: Type()
+            object Confirmable : Type()
+            object NonConfirmable : Type()
+            object Acknowledgement : Type()
+            object Reset : Type()
         }
 
         override fun equals(other: Any?): Boolean =

--- a/koap/src/commonMain/kotlin/Message.kt
+++ b/koap/src/commonMain/kotlin/Message.kt
@@ -1,7 +1,7 @@
 package com.juul.koap
 
-import com.juul.koap.Message.Option.Observe.Registration.Deregister
-import com.juul.koap.Message.Option.Observe.Registration.Register
+import kotlin.js.JsExport
+import kotlin.js.JsName
 
 /* RFC 7252 5.10. Table 4: Options
  * RFC 7641 2. The Observe Option (No. 6)
@@ -43,6 +43,7 @@ private val PROXY_SCHEME_LENGTH_RANGE = 1..255
 private val SIZE1_RANGE = UINT_RANGE
 private val OBSERVE_RANGE = 0..16_777_215 // 3-byte unsigned int
 
+@JsExport
 sealed class Message {
 
     abstract val code: Code
@@ -200,6 +201,7 @@ sealed class Message {
         /** RFC 7252 5.10.4. Accept */
         data class Accept(val format: Long) : Option() {
 
+            @JsName("constructorWithContentFormat")
             constructor(format: ContentFormat) : this(format.format)
 
             init {
@@ -291,17 +293,21 @@ sealed class Message {
              * - `0` (register) adds the entry to the list, if not present;
              * - `1` (deregister) removes the entry from the list, if present.
              */
-            enum class Registration { Register, Deregister }
+            sealed class Registration {
+                object Register: Registration()
+                object Deregister: Registration()
+            }
 
             /**
              * Constructs an [Observe] to be included in a GET request.
              *
              * @see Registration
              */
+            @JsName("constructorWithRegistration")
             constructor(action: Registration) : this(
                 when (action) {
-                    Register -> 0L
-                    Deregister -> 1L
+                    Message.Option.Observe.Registration.Register -> 0L
+                    Message.Option.Observe.Registration.Deregister -> 1L
                 }
             )
 
@@ -389,11 +395,11 @@ sealed class Message {
         override val payload: ByteArray
     ) : Message() {
 
-        enum class Type {
-            Confirmable,
-            NonConfirmable,
-            Acknowledgement,
-            Reset,
+        sealed class Type() {
+            object Confirmable: Type()
+            object NonConfirmable: Type()
+            object Acknowledgement: Type()
+            object Reset: Type()
         }
 
         override fun equals(other: Any?): Boolean =


### PR DESCRIPTION
Adds `@JsExport` annotations to explicitly state the Javascript API.

From https://kotlinlang.org/docs/reference/js-to-kotlin-interop.html#jsexport-annotation
> The @JsExport annotation is available in the current default compiler backend and the new IR compiler backend. If you are targeting the IR compiler backend, you must use the @JsExport annotation to make your functions visible from Kotlin in the first place.

In order to emit typescript type declarations we need to be using the IR compiler which requires these annotations, so this is one step towards that.

More importantly, these annotations are also understood by the legacy compiler and using them forces the code author to explicitly note what is and isn't available to Javascript.

Where feasible `@file:JsExport` has been used. Where a file contains public declarations that are not supported, the declarations that are supported have been annotated individually.

One messy refactor is replacement of the nested `enum` classes on the `Message` object as `enum` is not supported and using it precludes export of the `Message` class entirely.

There is more refactoring required in order to have the entire API exported, or removal/relocation of Kotlin specific language features that are nice-to-haves but can be done without. That step is best left for a separate PR.
