### PR TITLE
APD-966: NPM Shrinkwrap

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
     id("com.vanniktech.maven.publish") version "0.13.0" apply false
     id("org.jetbrains.dokka") version "1.4.10"
     id("binary-compatibility-validator") version "0.2.3"
-    id("lt.petuska.npm.publish") version "1.0.1" apply false
+    id("lt.petuska.npm.publish") version "1.0.2" apply false
 }
 
 allprojects {

--- a/koap/build.gradle.kts
+++ b/koap/build.gradle.kts
@@ -52,4 +52,11 @@ npmPublishing {
             registry = uri("https://npm.pkg.github.com")
         }
     }
+
+    publications {
+        val js by getting {
+            // Workaround for bug https://github.com/npm/cli/issues/2143
+            shrinkwrapBundledDependencies = true
+        }
+    }
 }

--- a/koap/build.gradle.kts
+++ b/koap/build.gradle.kts
@@ -52,11 +52,4 @@ npmPublishing {
             registry = uri("https://npm.pkg.github.com")
         }
     }
-
-    publications {
-        val js by getting {
-            // Workaround for bug https://github.com/npm/cli/issues/2143
-            shrinkwrapBundledDependencies = true
-        }
-    }
 }


### PR DESCRIPTION
Upgrade to v1.0.2 of NPM Publish and enable NPM bundle shrink-wrapping to workaround npm bugs with bundled dependencies:
https://github.com/npm/cli/issues/2143

Previously, the published NPM package could be installed via tarball but not via http as it would insist on querying the registry for bundled packages (that don't exist in the registry):
```
% npm install @juullabs/koap@0.4.0
npm ERR! 404 Not Found - GET https://registry.npmjs.org/okio-okio - Not found
npm ERR! 404 
npm ERR! 404  'okio-okio@2.9.0' is not in the npm registry.
```

The `shrinkwrapBundledDependencies` enables a hack that creates a `npm-shrinkwrap.json` alongside the `package.json` to override the dependency tree. See https://docs.npmjs.com/cli/v6/configuring-npm/shrinkwrap-json

*Note: `shrinkwrapBundledDependencies` option is enabled by default from v1.0.2*
