### PR TITLE
Fix JS API Test Task Chain

### DIFF
--- a/koap/apiTests/.gitignore
+++ b/koap/apiTests/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+package-lock.json
+

--- a/koap/build.gradle.kts
+++ b/koap/build.gradle.kts
@@ -56,7 +56,7 @@ npmPublishing {
     }
 }
 
-task<Exec>("apiTestNpmInstall") {
+task<Exec>("apiTestNpmInstallLocalBuild") {
     description = "Builds the JS Koap package and installs it to the test suite for use"
     group = "Verification"
     dependsOn("assembleJsNpmPublication")
@@ -64,18 +64,10 @@ task<Exec>("apiTestNpmInstall") {
     commandLine("npm", "install", "--force", "file://../build/publications/npm/js")
 }
 
-task<Exec>("apiTest") {
-    description = "Runs the validation package for testing against the built out JS api"
-    group = "Verification"
-    dependsOn("apiTestNpmInstall")
-    workingDir("apiTests")
-    commandLine("npm", "run", "test")
-}
-
-task<Exec>("apiTestLintBuild") {
+task<Exec>("apiTestNpmInstall") {
     description = "Installs the koap api to the test package along with devDependencies"
     group = "Verification"
-    dependsOn("assembleJsNpmPublication")
+    dependsOn("apiTestNpmInstallLocalBuild")
     workingDir("apiTests")
     commandLine("npm", "install", "--also=dev")
 }
@@ -83,11 +75,19 @@ task<Exec>("apiTestLintBuild") {
 task<Exec>("apiTestLint") {
     description = "Runs the linting system for testing against the built out JS api"
     group = "Verification"
-    dependsOn("apiTestLintBuild")
+    dependsOn("apiTestNpmInstall")
     workingDir("apiTests")
     commandLine("npm", "run", "lint")
 }
 
-tasks.named("check") {
+task<Exec>("apiTest") {
+    description = "Runs the validation package for testing against the built out JS api"
+    group = "Verification"
     dependsOn("apiTestLint")
+    workingDir("apiTests")
+    commandLine("npm", "run", "test")
+}
+
+tasks.named("check") {
+    dependsOn("apiTest")
 }


### PR DESCRIPTION
The Typescript API tests were not being run under the `check` task, only the linting of the tests. 🤦 

Rejiggered the task dependency chain such that both the linter and tests are executed. Also added a git ignore for the NPM artifacts.

Before:
```
$ ./gradlew check --info
[snip]
> Task :koap:apiCheck UP-TO-DATE

> Task :koap:assembleJsNpmPublication

> Task :koap:apiTestLintBuild

> Task :koap:apiTestLint

> Task :koap:lintKotlinCommonMain UP-TO-DATE
[snip]
```

After:
```
$ ./gradlew check --info
[snip]
> Task :koap:apiCheck UP-TO-DATE

> Task :koap:assembleJsNpmPublication

> Task :koap:apiTestNpmInstallLocalBuild

> Task :koap:apiTestNpmInstall

> Task :koap:apiTestLint

> Task :koap:apiTest
> jest

PASS ./decoder.test.ts
PASS ./encoder.test.ts

Test Suites: 2 passed, 2 total
Tests:       8 passed, 8 total
Snapshots:   0 total
Time:        1.435s
Ran all test suites.

> Task :koap:lintKotlinCommonMain UP-TO-DATE
[snip]
```