### PR TITLE
Drop jcenter for mavenCentral

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ Message.Udp(
 
 ```groovy
 repositories {
-    jcenter() // or mavenCentral()
+    mavenCentral()
 }
 
 dependencies {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,12 +8,12 @@ buildscript {
 }
 
 plugins {
-    kotlin("multiplatform") version "1.4.30" apply false
-    kotlin("js") version "1.4.30" apply false
-    kotlin("plugin.serialization") version "1.4.30" apply false
+    kotlin("multiplatform") version "1.4.21" apply false
+    kotlin("js") version "1.4.21" apply false
+    kotlin("plugin.serialization") version "1.4.21" apply false
     id("org.jmailen.kotlinter") version "3.2.0" apply false
     id("com.vanniktech.maven.publish") version "0.13.0" apply false
-    id("org.jetbrains.dokka") version "1.4.30"
+    id("org.jetbrains.dokka") version "1.4.20"
     id("binary-compatibility-validator") version "0.2.3"
     id("lt.petuska.npm.publish") version "1.0.4" apply false
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,24 +3,24 @@ import org.jetbrains.dokka.gradle.DokkaMultiModuleTask
 
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
     }
 }
 
 plugins {
-    kotlin("multiplatform") version "1.4.21" apply false
-    kotlin("js") version "1.4.21" apply false
-    kotlin("plugin.serialization") version "1.4.21" apply false
+    kotlin("multiplatform") version "1.4.30" apply false
+    kotlin("js") version "1.4.30" apply false
+    kotlin("plugin.serialization") version "1.4.30" apply false
     id("org.jmailen.kotlinter") version "3.2.0" apply false
     id("com.vanniktech.maven.publish") version "0.13.0" apply false
-    id("org.jetbrains.dokka") version "1.4.20"
+    id("org.jetbrains.dokka") version "1.4.30"
     id("binary-compatibility-validator") version "0.2.3"
     id("lt.petuska.npm.publish") version "1.0.4" apply false
 }
 
 allprojects {
     repositories {
-        jcenter()
+        mavenCentral()
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,13 +18,20 @@ plugins {
     id("lt.petuska.npm.publish") version "1.0.4" apply false
 }
 
-allprojects {
+subprojects {
     repositories {
         mavenCentral()
-    }
-}
+        jcenter {
+            content {
+                // https://youtrack.jetbrains.com/issue/IDEA-261387
+                includeModule("org.jetbrains.trove4j", "trove4j")
 
-subprojects {
+                // https://github.com/Kotlin/kotlinx.html/issues/173
+                includeModule("org.jetbrains.kotlinx", "kotlinx-html-jvm")
+            }
+        }
+    }
+
     tasks.withType<Test>().configureEach {
         testLogging {
             events("started", "passed", "skipped", "failed", "standardOut", "standardError")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,7 +18,7 @@ plugins {
     id("lt.petuska.npm.publish") version "1.0.4" apply false
 }
 
-subprojects {
+allprojects {
     repositories {
         mavenCentral()
         jcenter {

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -3,5 +3,5 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }


### PR DESCRIPTION
Due to Bintray (including `jcenter`) being [sunset], changing over to using `mavenCentral`.

[sunset]: https://www.reddit.com/r/java/comments/lbstco/bintray_including_jcenter_will_be_sunset_on_may/