### PR TITLE
Upgrade Dokka

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,4 @@
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
-import org.jetbrains.dokka.gradle.DokkaMultiModuleTask
 
 buildscript {
     repositories {
@@ -8,12 +7,12 @@ buildscript {
 }
 
 plugins {
-    kotlin("multiplatform") version "1.4.21" apply false
-    kotlin("js") version "1.4.21" apply false
-    kotlin("plugin.serialization") version "1.4.21" apply false
+    kotlin("multiplatform") version "1.4.31" apply false
+    kotlin("js") version "1.4.31" apply false
+    kotlin("plugin.serialization") version "1.4.31" apply false
     id("org.jmailen.kotlinter") version "3.2.0" apply false
     id("com.vanniktech.maven.publish") version "0.13.0" apply false
-    id("org.jetbrains.dokka") version "1.4.20"
+    id("org.jetbrains.dokka") version "1.4.30"
     id("binary-compatibility-validator") version "0.2.3"
     id("lt.petuska.npm.publish") version "1.0.4" apply false
 }
@@ -43,19 +42,11 @@ allprojects {
     }
 }
 
-tasks.withType<DokkaMultiModuleTask>().configureEach {
-    val dokkaDir = buildDir.resolve("dokkaHtmlMultiModule")
-    outputDirectory.set(dokkaDir)
-    doLast {
-        dokkaDir.resolve("-modules.html").renameTo(dokkaDir.resolve("index.html"))
-    }
-}
-
 task<Copy>("assembleGitHubPages") {
     description = "Generates static web site for GitHub Pages."
     group = "Build"
 
-    dependsOn(":webapp:browserDevelopmentWebpack", "dokkaHtmlMultiModule")
+    dependsOn(":webapp:browserDevelopmentWebpack", ":koap:dokkaHtml")
 
     into("$buildDir/gh-pages")
     from("${project(":webapp").buildDir}/distributions") {
@@ -63,7 +54,7 @@ task<Copy>("assembleGitHubPages") {
     }
 
     into("docs") {
-        from("$buildDir/dokkaHtmlMultiModule") {
+        from("${project(":koap").buildDir}/dokka/html") {
             include("**")
         }
     }


### PR DESCRIPTION
Bugs surrounding relative paths in generated Dokka HTML have been fixed and we no longer need to execute Dokka with multi-module support (instead being able to simply generate Dokka HTML for `koap` module) — this ultimately results in simpler Gradle configuration.