### PR TITLE
Remove Js annotations

### DIFF
--- a/koap/src/commonMain/kotlin/Decoder.kt
+++ b/koap/src/commonMain/kotlin/Decoder.kt
@@ -97,7 +97,6 @@ inline fun <reified T : Message> ByteArray.decode(): T =
  * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
  * ```
  */
-
 fun ByteArray.decodeUdp(): Message.Udp {
     val header = decodeUdpHeader()
     return decode(header, offset = header.size)
@@ -121,7 +120,6 @@ fun ByteArray.decodeUdp(): Message.Udp {
  * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
  * ```
  */
-
 fun ByteArray.decodeTcp(): Message.Tcp {
     val header = decodeTcpHeader()
     return decode(header, offset = header.size)
@@ -148,7 +146,6 @@ fun ByteArray.decodeTcp(): Message.Tcp {
  * val message = encoded.decode(content, offset = 0)
  * ```
  */
-
 fun ByteArray.decode(
     header: Header.Udp,
     offset: Int = header.size
@@ -175,7 +172,6 @@ fun ByteArray.decode(
  * val message = content.decode(content, offset = 0)
  * ```
  */
-
 fun ByteArray.decode(
     header: Header.Tcp,
     offset: Int = header.size
@@ -233,7 +229,6 @@ private fun ByteArray.decodeContent(
  * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
  * ```
  */
-
 fun ByteArray.decodeUdpHeader(): Header.Udp = withReader {
     // |7 6 5 4 3 2 1 0|
     // +-+-+-+-+-+-+-+-+
@@ -284,7 +279,6 @@ fun ByteArray.decodeUdpHeader(): Header.Udp = withReader {
  * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
  * ```
  */
-
 fun ByteArray.decodeTcpHeader(): Header.Tcp = withReader {
     // |7 6 5 4 3 2 1 0|
     // +-+-+-+-+-+-+-+-+

--- a/koap/src/commonMain/kotlin/Decoder.kt
+++ b/koap/src/commonMain/kotlin/Decoder.kt
@@ -48,8 +48,6 @@ import com.juul.koap.Message.Udp.Type.Confirmable
 import com.juul.koap.Message.Udp.Type.NonConfirmable
 import com.juul.koap.Message.Udp.Type.Reset
 import okio.BufferedSource
-import kotlin.js.JsExport
-import kotlin.js.JsName
 
 /**
  * Decodes [ByteArray] receiver to a [Message].
@@ -99,7 +97,7 @@ inline fun <reified T : Message> ByteArray.decode(): T =
  * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
  * ```
  */
-@JsExport
+
 fun ByteArray.decodeUdp(): Message.Udp {
     val header = decodeUdpHeader()
     return decode(header, offset = header.size)
@@ -123,7 +121,7 @@ fun ByteArray.decodeUdp(): Message.Udp {
  * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
  * ```
  */
-@JsExport
+
 fun ByteArray.decodeTcp(): Message.Tcp {
     val header = decodeTcpHeader()
     return decode(header, offset = header.size)
@@ -150,8 +148,7 @@ fun ByteArray.decodeTcp(): Message.Tcp {
  * val message = encoded.decode(content, offset = 0)
  * ```
  */
-@JsExport
-@JsName("decodeWithUdpHeader")
+
 fun ByteArray.decode(
     header: Header.Udp,
     offset: Int = header.size
@@ -178,8 +175,7 @@ fun ByteArray.decode(
  * val message = content.decode(content, offset = 0)
  * ```
  */
-@JsExport
-@JsName("decodeWithTcpHeader")
+
 fun ByteArray.decode(
     header: Header.Tcp,
     offset: Int = header.size
@@ -237,7 +233,7 @@ private fun ByteArray.decodeContent(
  * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
  * ```
  */
-@JsExport
+
 fun ByteArray.decodeUdpHeader(): Header.Udp = withReader {
     // |7 6 5 4 3 2 1 0|
     // +-+-+-+-+-+-+-+-+
@@ -288,7 +284,7 @@ fun ByteArray.decodeUdpHeader(): Header.Udp = withReader {
  * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
  * ```
  */
-@JsExport
+
 fun ByteArray.decodeTcpHeader(): Header.Tcp = withReader {
     // |7 6 5 4 3 2 1 0|
     // +-+-+-+-+-+-+-+-+

--- a/koap/src/commonMain/kotlin/Encoder.kt
+++ b/koap/src/commonMain/kotlin/Encoder.kt
@@ -1,5 +1,3 @@
-@file:JsExport
-
 package com.juul.koap
 
 import com.juul.koap.Message.Option
@@ -16,7 +14,6 @@ import com.juul.koap.Message.Udp.Type.NonConfirmable
 import com.juul.koap.Message.Udp.Type.Reset
 import okio.Buffer
 import okio.BufferedSink
-import kotlin.js.JsExport
 
 internal const val UINT32_MAX_EXTENDED_LENGTH = UINT_MAX_VALUE + 65805L
 

--- a/koap/src/commonMain/kotlin/Header.kt
+++ b/koap/src/commonMain/kotlin/Header.kt
@@ -1,10 +1,7 @@
-@file:JsExport
-
 package com.juul.koap
 
 import com.juul.koap.Message.Code
 import com.juul.koap.Message.Udp.Type
-import kotlin.js.JsExport
 
 sealed class Header {
 

--- a/koap/src/commonMain/kotlin/Message.kt
+++ b/koap/src/commonMain/kotlin/Message.kt
@@ -5,8 +5,6 @@ package com.juul.koap
 
 import com.juul.koap.Message.Option.Observe.Registration.Deregister
 import com.juul.koap.Message.Option.Observe.Registration.Register
-import kotlin.js.JsExport
-import kotlin.js.JsName
 
 /* RFC 7252 5.10. Table 4: Options
  * RFC 7641 2. The Observe Option (No. 6)
@@ -48,7 +46,6 @@ private val PROXY_SCHEME_LENGTH_RANGE = 1..255
 private val SIZE1_RANGE = UINT_RANGE
 private val OBSERVE_RANGE = 0..16_777_215 // 3-byte unsigned int
 
-@JsExport
 sealed class Message {
 
     abstract val code: Code
@@ -208,7 +205,6 @@ sealed class Message {
         /** RFC 7252 5.10.4. Accept */
         data class Accept(val format: Long) : Option() {
 
-            @JsName("fromContentFormat")
             constructor(format: ContentFormat) : this(format.format)
 
             init {
@@ -310,7 +306,6 @@ sealed class Message {
              *
              * @see Registration
              */
-            @JsName("fromRegistration")
             constructor(action: Registration) : this(
                 when (action) {
                     Register -> 0L


### PR DESCRIPTION
Removes the `@JsName` and `@JsExport` annotations from the `koap` module 