### PR TITLE
Add `macosX64` platform target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,48 +1,38 @@
 name: CI
 on:
-  push:
+  pull_request:
+
+env:
+  GRADLE_OPTS: "-Dorg.gradle.daemon=false"
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
-
-    env:
-      GRADLE_ARGS: >-
-        --no-daemon
-        --max-workers 2
-        -Pkotlin.incremental=false
-
+    runs-on: macos-11
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Validate Gradle wrapper
-        uses: gradle/wrapper-validation-action@v1
-
-      - name: Set up JDK
-        uses: actions/setup-java@v1
+      - uses: actions/checkout@v2
+      - uses: gradle/wrapper-validation-action@v1
+      - uses: actions/setup-java@v2
         with:
-          java-version: 1.8
-
-      - name: Gradle cache
-        uses: actions/cache@v2
+          distribution: "adopt-hotspot"
+          java-version: "11.0.11+9"
+      - uses: actions/cache@v2
         with:
           path: |
             ~/.gradle/caches
             ~/.gradle/wrapper
             ~/.konan
-          key: ${{ runner.os }}-build-${{ hashFiles('**/build.gradle.kts') }}
+          key: ${{ runner.os }}-build-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: |
             ${{ runner.os }}-build-
             ${{ runner.os }}-
 
-      - name: Check
-        run: ./gradlew $GRADLE_ARGS check jacocoTestReport
+      - run: ./gradlew check jacocoTestReport
+      - run: ./gradlew assembleGitHubPages
 
-      - name: Build webapp
-        run: ./gradlew $GRADLE_ARGS assembleGitHubPages
-
-      - name: Codecov
-        uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v1
         with:
           fail_ci_if_error: true
+
+      - run: |
+          rm -f ~/.gradle/caches/modules-2/modules-2.lock
+          rm -f ~/.gradle/caches/modules-2/gc.properties

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -4,42 +4,33 @@ on:
     branches:
       - main
 
+env:
+  GRADLE_OPTS: "-Dorg.gradle.daemon=false"
+
 jobs:
   deploy:
-    runs-on: ubuntu-18.04
-
-    env:
-      GRADLE_ARGS: >-
-        --no-daemon
-        --max-workers 2
-        -Pkotlin.incremental=false
-
+    runs-on: ubuntu-20.04
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Set up JDK
-        uses: actions/setup-java@v1
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v2
         with:
-          java-version: 1.8
+          distribution: "adopt-hotspot"
+          java-version: "11.0.11+9"
 
-      - name: Gradle cache
-        uses: actions/cache@v2
+      - uses: actions/cache@v2
         with:
           path: |
             ~/.gradle/caches
             ~/.gradle/wrapper
             ~/.konan
-          key: ${{ runner.os }}-gh-pages-${{ hashFiles('**/build.gradle.kts') }}
+          key: ${{ runner.os }}-gh-pages-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: |
             ${{ runner.os }}-gh-pages-
             ${{ runner.os }}-
 
-      - name: Build webapp
-        run: ./gradlew $GRADLE_ARGS assembleGitHubPages
+      - run: ./gradlew assembleGitHubPages
 
-      - name: Deploy to Github Pages
-        uses: JamesIves/github-pages-deploy-action@3.7.1
+      - uses: JamesIves/github-pages-deploy-action@3.7.1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: gh-pages

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,49 +6,30 @@ on:
 
 jobs:
   publish:
-    runs-on: macos-10.15
-
-    env:
-      GRADLE_ARGS: >-
-        --no-daemon
-        --max-workers 2
-        -Pkotlin.incremental=false
-
+    runs-on: macos-11
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Validate Gradle wrapper
-        uses: gradle/wrapper-validation-action@v1
-
-      - name: Set up JDK
-        uses: actions/setup-java@v1
+      - uses: actions/checkout@v2
+      - uses: gradle/wrapper-validation-action@v1
+      - uses: actions/setup-java@v2
         with:
-          java-version: 1.8
+          distribution: "adopt-hotspot"
+          java-version: "11.0.11+9"
 
-      - name: Gradle cache
-        uses: actions/cache@v1
+      - uses: actions/cache@v2
         with:
           path: |
             ~/.gradle/caches
             ~/.gradle/wrapper
             ~/.konan
-          key: ${{ runner.os }}-publish-${{ hashFiles('**/build.gradle.kts') }}
+          key: ${{ runner.os }}-publish-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: |
             ${{ runner.os }}-publish-
             ${{ runner.os }}-
 
-      - name: Check
-        run: ./gradlew $GRADLE_ARGS check
+      - run: ./gradlew check
 
-      - name: Keyring
-        run: echo "${{ secrets.SIGNING_SECRET_KEY_RING }}" | base64 --decode > ~/secring.gpg
-
-      - name: Maven Publish
-        env:
-          SONATYPE_NEXUS_USERNAME: ${{ secrets.OSS_SONATYPE_NEXUS_USERNAME }}
-          SONATYPE_NEXUS_PASSWORD: ${{ secrets.OSS_SONATYPE_NEXUS_PASSWORD }}
-        run: >-
+      - run: echo "${{ secrets.SIGNING_SECRET_KEY_RING }}" | base64 --decode > ~/secring.gpg
+      - run: >-
           ./gradlew
           $GRADLE_ARGS
           --no-parallel
@@ -57,3 +38,10 @@ jobs:
           -Psigning.password="${{ secrets.SIGNING_PASSWORD }}"
           -Psigning.secretKeyRingFile="$HOME/secring.gpg"
           uploadArchives
+        env:
+          SONATYPE_NEXUS_USERNAME: ${{ secrets.OSS_SONATYPE_NEXUS_USERNAME }}
+          SONATYPE_NEXUS_PASSWORD: ${{ secrets.OSS_SONATYPE_NEXUS_PASSWORD }}
+
+      - run: |
+          rm -f ~/.gradle/caches/modules-2/modules-2.lock
+          rm -f ~/.gradle/caches/modules-2/gc.properties

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -4,47 +4,35 @@ on:
     branches:
       - main
 
+env:
+  GRADLE_OPTS: "-Dorg.gradle.daemon=false"
+
 jobs:
   snapshot:
-    runs-on: ubuntu-18.04
-
-    env:
-      GRADLE_ARGS: >-
-        --no-daemon
-        --max-workers 2
-        -Pkotlin.incremental=false
-
+    runs-on: macos-11
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Set up JDK
-        uses: actions/setup-java@v1
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v2
         with:
-          java-version: 1.8
-
-      - name: Gradle cache
-        uses: actions/cache@v2
+          distribution: "adopt-hotspot"
+          java-version: "11.0.11+9"
+      - uses: actions/cache@v2
         with:
           path: |
             ~/.gradle/caches
             ~/.gradle/wrapper
             ~/.konan
-          key: ${{ runner.os }}-snapshot-${{ hashFiles('**/build.gradle.kts') }}
+          key: ${{ runner.os }}-snapshot-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: |
             ${{ runner.os }}-snapshot-
             ${{ runner.os }}-
 
-      - name: Check
-        run: ./gradlew $GRADLE_ARGS check
-
-      - name: Snapshot
+      - run: ./gradlew check
+      - run: ./gradlew --no-parallel -PVERSION_NAME=main-SNAPSHOT uploadArchives
         env:
           SONATYPE_NEXUS_USERNAME: ${{ secrets.OSS_SONATYPE_NEXUS_USERNAME }}
           SONATYPE_NEXUS_PASSWORD: ${{ secrets.OSS_SONATYPE_NEXUS_PASSWORD }}
-        run: >-
-          ./gradlew
-          $GRADLE_ARGS
-          --no-parallel
-          -PVERSION_NAME=main-SNAPSHOT
-          uploadArchives
+
+      - run: |
+          rm -f ~/.gradle/caches/modules-2/modules-2.lock
+          rm -f ~/.gradle/caches/modules-2/gc.properties

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,3 +16,6 @@ POM_LICENSE_DIST=repo
 POM_DEVELOPER_ID=twyatt
 POM_DEVELOPER_NAME=Travis Wyatt
 POM_DEVELOPER_URL=https://github.com/twyatt
+
+# Workaround for `java.lang.OutOfMemoryError: Metaspace` on CI.
+org.gradle.jvmargs=-XX:MaxMetaspaceSize=512m

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-kotlin = "1.5.10"
+kotlin = "1.6.0"
 okio = "3.0.0-alpha.6"
 jacoco = "0.8.7"
 
@@ -18,4 +18,4 @@ kotlinx-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", vers
 kotlinter = { id = "org.jmailen.kotlinter", version = "3.2.0" }
 maven-publish = { id = "com.vanniktech.maven.publish", version = "0.14.0" }
 dokka = { id = "org.jetbrains.dokka", version = "1.4.32" }
-binary-compatibility-validator = { id = "binary-compatibility-validator", version = "0.6.0" }
+binary-compatibility-validator = { id = "binary-compatibility-validator", version = "0.8.0" }

--- a/koap/build.gradle.kts
+++ b/koap/build.gradle.kts
@@ -16,6 +16,7 @@ jacoco {
 kotlin {
     jvm()
     js(BOTH).browser()
+    macosX64()
 
     sourceSets {
         val commonMain by getting {


### PR DESCRIPTION
Upgraded Kotlin to 1.6.0.
Updated build scripts to support building/publishing of a MacOS target.

The `macosX64` target is needed for an internal tool that parses CoAP based I/O.