### PR TITLE
Use in-memory ascii-armored key for signing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,23 @@ jobs:
       - run: ./gradlew check jacocoTestReport
       - run: ./gradlew assembleGitHubPages
 
+      - run: |
+          set -o xtrace
+          if [ ! -z "${{ secrets.SIGNING_KEY }}" ]; then
+            ./gradlew \
+            --no-parallel \
+            -PVERSION_NAME="unspecified" \
+            -PsigningInMemoryKey="${{ secrets.SIGNING_KEY }}" \
+            -PsigningInMemoryKeyPassword="${{ secrets.SIGNING_PASSWORD }}" \
+            publishToMavenLocal
+          else
+            ./gradlew \
+            --no-parallel \
+            -PVERSION_NAME="unspecified-SNAPSHOT" \
+            publishToMavenLocal
+          fi
+        if: ${{ runner.os == 'macOS' && github.repository_owner == 'JuulLabs' }}
+
       - uses: codecov/codecov-action@v1
         with:
           fail_ci_if_error: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,20 +27,15 @@ jobs:
             ${{ runner.os }}-
 
       - run: ./gradlew check
-
-      - run: echo "${{ secrets.SIGNING_SECRET_KEY_RING }}" | base64 --decode > ~/secring.gpg
       - run: >-
           ./gradlew
-          $GRADLE_ARGS
           --no-parallel
-          -PVERSION_NAME=${GITHUB_REF/refs\/tags\//}
-          -Psigning.keyId="${{ secrets.SIGNING_KEY_ID }}"
-          -Psigning.password="${{ secrets.SIGNING_PASSWORD }}"
-          -Psigning.secretKeyRingFile="$HOME/secring.gpg"
-          uploadArchives
-        env:
-          SONATYPE_NEXUS_USERNAME: ${{ secrets.OSS_SONATYPE_NEXUS_USERNAME }}
-          SONATYPE_NEXUS_PASSWORD: ${{ secrets.OSS_SONATYPE_NEXUS_PASSWORD }}
+          -PVERSION_NAME="${GITHUB_REF/refs\/tags\//}"
+          -PsigningInMemoryKey="${{ secrets.SIGNING_KEY }}"
+          -PsigningInMemoryKeyPassword="${{ secrets.SIGNING_PASSWORD }}"
+          -PmavenCentralUsername="${{ secrets.OSS_SONATYPE_NEXUS_USERNAME }}"
+          -PmavenCentralPassword="${{ secrets.OSS_SONATYPE_NEXUS_PASSWORD }}"
+          publish
 
       - run: |
           rm -f ~/.gradle/caches/modules-2/modules-2.lock

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -28,10 +28,13 @@ jobs:
             ${{ runner.os }}-
 
       - run: ./gradlew check
-      - run: ./gradlew --no-parallel -PVERSION_NAME=main-SNAPSHOT uploadArchives
-        env:
-          SONATYPE_NEXUS_USERNAME: ${{ secrets.OSS_SONATYPE_NEXUS_USERNAME }}
-          SONATYPE_NEXUS_PASSWORD: ${{ secrets.OSS_SONATYPE_NEXUS_PASSWORD }}
+      - run: >
+          ./gradlew
+          --no-parallel
+          -PVERSION_NAME=main-SNAPSHOT
+          -PmavenCentralUsername="${{ secrets.OSS_SONATYPE_NEXUS_USERNAME }}"
+          -PmavenCentralPassword="${{ secrets.OSS_SONATYPE_NEXUS_PASSWORD }}"
+          publish
 
       - run: |
           rm -f ~/.gradle/caches/modules-2/modules-2.lock

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,6 +16,6 @@ kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref 
 kotlin-js = { id = "org.jetbrains.kotlin.js", version.ref = "kotlin" }
 kotlinx-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 kotlinter = { id = "org.jmailen.kotlinter", version = "3.2.0" }
-maven-publish = { id = "com.vanniktech.maven.publish", version = "0.14.0" }
+maven-publish = { id = "com.vanniktech.maven.publish", version = "0.18.0" }
 dokka = { id = "org.jetbrains.dokka", version = "1.4.32" }
 binary-compatibility-validator = { id = "binary-compatibility-validator", version = "0.8.0" }


### PR DESCRIPTION
Using built in GPG mechanisms ([supported by Gradle](https://docs.gradle.org/current/userguide/signing_plugin.html#using_in_memory_ascii_armored_openpgp_subkeys)) for storing keys as plain text (as GitHub secret), rather than the previously used method of base64'ing the binary key ring.