### PR TITLE
Disable codecov GitHub status

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,6 @@
+coverage:
+  status:
+    project: off
+    patch: off
 fixes:
   - "com/juul/koap::"


### PR DESCRIPTION
With code coverage at times varying wildly (without code changes) these checks are just adding noise:

![Screen Shot 2021-12-20 at 4 35 38 PM](https://user-images.githubusercontent.com/98017/146851126-3b8ce7c3-f50a-407d-8600-84f138f6a7c9.png)

We can re-enable later if we find better tooling for code coverage.