### PR TITLE
Reduce number of `npm` dependencies and simplify webpack configuration

### DIFF
--- a/koap/build.gradle.kts
+++ b/koap/build.gradle.kts
@@ -32,12 +32,6 @@ kotlin {
             }
         }
 
-        val jsMain by getting {
-            dependencies {
-                implementation(npm("os-browserify", "0.3.0"))
-            }
-        }
-
         val jvmTest by getting {
             dependencies {
                 implementation(kotlin("test-junit"))

--- a/koap/webpack.config.d/webpack.js
+++ b/koap/webpack.config.d/webpack.js
@@ -1,4 +1,0 @@
-config.resolve.fallback = {
-    "path": require.resolve("path-browserify"),
-    "os": require.resolve("os-browserify/browser"),
-}

--- a/webapp/build.gradle.kts
+++ b/webapp/build.gradle.kts
@@ -18,11 +18,14 @@ kotlin {
                 implementation(libs.okio.js)
                 implementation(npm("buffer", "6.0.3"))
                 implementation(npm("cbor", "8.1.0"))
-                implementation(npm("os-browserify", "0.3.0"))
-                implementation(npm("path-browserify", "1.0.1"))
                 implementation(npm("process", "0.11.10"))
                 implementation(npm("stream-browserify", "3.0.0"))
-                implementation(npm("util", "0.12.4"))
+            }
+        }
+
+        val test by getting {
+            dependencies {
+                implementation(kotlin("test-js"))
             }
         }
     }

--- a/webapp/src/main/kotlin/webapp.kt
+++ b/webapp/src/main/kotlin/webapp.kt
@@ -1,6 +1,5 @@
 package com.juul.koap
 
-import cbor.decodeFirstSync
 import cbor.diagnose
 import com.juul.koap.Message.Option.Accept
 import com.juul.koap.Message.Option.ContentFormat
@@ -68,7 +67,7 @@ fun decode(hex: String?): Promise<String> = GlobalScope.promise {
     }
 }
 
-private suspend inline fun <reified T : Message> decode(bytes: ByteArray): String = try {
+internal suspend inline fun <reified T : Message> decode(bytes: ByteArray): String = try {
     parse(bytes.decode<T>())
 } catch (t: Throwable) {
     console.error(t)

--- a/webapp/src/test/kotlin/DecodingTest.kt
+++ b/webapp/src/test/kotlin/DecodingTest.kt
@@ -1,0 +1,114 @@
+package com.juul.koap
+
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.promise
+import okio.ByteString.Companion.decodeHex
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DecodingTest {
+
+    @Test
+    fun coapWithJsonPayload() = GlobalScope.promise {
+        /* Message.Udp(
+         *     type = Confirmable,
+         *     code = GET,
+         *     id = 0xFEED,
+         *     token = 0xCAFE,
+         *     options = listOf(
+         *         UriPath("example"),
+         *         ContentFormat.JSON,
+         *     ),
+         *     payload = {"example": 123}
+         * )
+         */
+        val input = "42 01 FE ED CA FE B7 65 78 61 6D 70 6C 65 11 32 FF 7B 22 65 78 61 6D 70 6C 65 22 3A 20 31 32 33 7D"
+            .replace(" ", "")
+            .decodeHex()
+            .toByteArray()
+
+        assertEquals(
+            expected = """
+                <b>Message:</b>
+                {
+                  "type": "Confirmable",
+                  "code": "GET",
+                  "id": 65261,
+                  "token": 51966,
+                  "options": [
+                    "UriPath(uri=example)",
+                    "Content-Format: application/json"
+                  ]
+                }
+
+                <b>Payload (JSON):</b>
+                {
+                  "example": 123
+                }
+            """.trimIndent(),
+            actual = decode<Message.Udp>(input).trim(),
+        )
+
+        assertEquals(
+            expected = "Unsupported number length of 10 bytes",
+            actual = decode<Message.Tcp>(input),
+        )
+    }
+
+    @Test
+    fun coapWithCborPayload() = GlobalScope.promise {
+        /* Message.Udp(
+         *     type = Confirmable,
+         *     code = GET,
+         *     id = 0xFEED,
+         *     token = 0xCAFE,
+         *     options = listOf(
+         *         UriPath("example"),
+         *         ContentFormat.CBOR,
+         *     ),
+         *     payload = <CBOR>,
+         * )
+         *
+         * CBOR payload:
+         * BF           # map(*)
+         *   61        # text(1)
+         *      61     # "a"
+         *   63        # text(3)
+         *      313233 # "123"
+         *   61        # text(1)
+         *      62     # "b"
+         *   63        # text(3)
+         *      393837 # "987"
+         *   FF        # primitive(*)
+         */
+        val input = "42 01 FE ED CA FE B7 65 78 61 6D 70 6C 65 11 3C FF BF 61 61 63 31 32 33 61 62 63 39 38 37 FF"
+            .replace(" ", "")
+            .decodeHex()
+            .toByteArray()
+
+        assertEquals(
+            expected = "Unsupported number length of 10 bytes",
+            actual = decode<Message.Tcp>(input),
+        )
+
+        assertEquals(
+            expected = """
+                <b>Message:</b>
+                {
+                  "type": "Confirmable",
+                  "code": "GET",
+                  "id": 65261,
+                  "token": 51966,
+                  "options": [
+                    "UriPath(uri=example)",
+                    "Content-Format: application/cbor"
+                  ]
+                }
+
+                <b>Payload (CBOR):</b>
+                {_ "a": "123", "b": "987"}
+            """.trimIndent(),
+            actual = decode<Message.Udp>(input).trim(),
+        )
+    }
+}

--- a/webapp/webpack.config.d/webpack.js
+++ b/webapp/webpack.config.d/webpack.js
@@ -8,8 +8,6 @@ config.plugins = [
 
 config.resolve.fallback = {
     "buffer": require.resolve("buffer/"),
-    "os": require.resolve("os-browserify/browser"),
     "process": require.resolve("process/browser"),
     "stream": require.resolve("stream-browserify"),
-    "util": require.resolve("util/"),
 }


### PR DESCRIPTION
Added tests to confirm that decoding works for webapp with reduced `npm` dependencies and webpack configuration (and prevent future regressions).