### PR TITLE
Require version label on pull requests

### DIFF
--- a/.github/workflows/version-labels.yml
+++ b/.github/workflows/version-labels.yml
@@ -1,0 +1,13 @@
+name: Version Labels
+on:
+  pull_request:
+    types: [opened, labeled, unlabeled, synchronize]
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mheap/github-action-required-labels@v2
+        with:
+          mode: exactly
+          count: 1
+          labels: "patch, minor, major, maintenance, renovate"


### PR DESCRIPTION
PRs must have exactly one of the following labels:
- `major`
- `minor`
- `patch`
- `maintenance` (use for non-code changes, e.g. dependency/build script updates)
- `renovate` _(used by Renovate bot, we shouldn't use this label manually)_

PRs can have as many/few of other labels as desired.

Adding/removing labels will re-run the `Version Labels` check.
