### PR TITLE
Remove metadata workaround

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,17 +2,6 @@ buildscript {
     repositories {
         mavenCentral()
     }
-
-    dependencies {
-        // Workaround for:
-        // > Incompatible version of Kotlin metadata.
-        // > Maximal supported Kotlin metadata version: 1.5.1,
-        // > com/juul/koap/ByteArrayReader Kotlin metadata version: 1.7.1.
-        // > As a workaround, it is possible to manually update 'kotlinx-metadata-jvm' version in your project.
-        //
-        // todo: Remove when binary-compatibility-validator bundles support for metadata 1.7.x.
-        classpath("org.jetbrains.kotlinx:kotlinx-metadata-jvm:0.6.0")
-    }
 }
 
 plugins {


### PR DESCRIPTION
This seems to have been resolved after upgrading a number of dependencies:

| Dependency | Version |
|-|-|
| Kotlin | 1.8.10 |
| Gradle | 8 |
| AtomicFU | 0.19.0 |
| binary-compatibility-validator | 0.13.0 |