### PR TITLE
Make codecov optional

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,8 +43,6 @@ jobs:
         if: ${{ runner.os == 'macOS' && github.repository_owner == 'JuulLabs' }}
 
       - uses: codecov/codecov-action@v3
-        with:
-          fail_ci_if_error: true
 
       - run: |
           rm -f ~/.gradle/caches/modules-2/modules-2.lock


### PR DESCRIPTION
No longer fail CI check when codecov fails to upload.