### PR TITLE
Use Kotlin DSL syntax in Gradle instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,13 +214,13 @@ Message.Udp(
 
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.juul.koap/koap/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.juul.koap/koap)
 
-```groovy
+```kotlin
 repositories {
     mavenCentral()
 }
 
 dependencies {
-    implementation 'com.juul.koap:koap:$version'
+    implementation("com.juul.koap:koap:$version")
 }
 ```
 


### PR DESCRIPTION
Rendered markdown [here](https://github.com/JuulLabs/koap/tree/twyatt/readme/gradle#gradle).