### PR TITLE
Use shields.io for Maven Central version badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ Message.Udp(
 
 ## Gradle
 
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.juul.koap/koap/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.juul.koap/koap)
+[![Maven Central](https://img.shields.io/maven-central/v/com.juul.koap/koap)](https://central.sonatype.com/search?q=g%253Acom.juul.koap)
 
 ```groovy
 repositories {


### PR DESCRIPTION
The old badge provider stopped working (badge was stuck on "unknown"). Switched to using shields.io.

Rendered markdown can be found [here](https://github.com/JuulLabs/koap/tree/twyatt/readme/maven-badge#gradle).