### PR TITLE
Use major-only version for `github-pages-deploy-action`

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -30,6 +30,6 @@ jobs:
 
       - run: ./gradlew assembleGitHubPages
 
-      - uses: JamesIves/github-pages-deploy-action@v4.4.1
+      - uses: JamesIves/github-pages-deploy-action@v4
         with:
           folder: build/gh-pages


### PR DESCRIPTION
Noticed that this action has major-only version tags available, which reduces version bump churn.