### PR TITLE
Fix directory from which webapp is pulled for GitHub pages

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,7 +38,7 @@ task<Copy>("assembleGitHubPages") {
     dependsOn(":webapp:browserDevelopmentWebpack", ":koap:dokkaHtml")
 
     into("$buildDir/gh-pages")
-    from("${project(":webapp").buildDir}/developmentExecutable") {
+    from("${project(":webapp").buildDir}/dist/js/developmentExecutable") {
         include("**")
     }
 


### PR DESCRIPTION
I'm guessing the build directory changed with the upgrade to Kotlin 1.9.0 (#203).

Closes #205