### PR TITLE
Mark `Registration` sub types as `data object`s

### DIFF
--- a/koap/api/koap.api
+++ b/koap/api/koap.api
@@ -363,10 +363,16 @@ public abstract class com/juul/koap/Message$Option$Observe$Registration {
 
 public final class com/juul/koap/Message$Option$Observe$Registration$Deregister : com/juul/koap/Message$Option$Observe$Registration {
 	public static final field INSTANCE Lcom/juul/koap/Message$Option$Observe$Registration$Deregister;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public final class com/juul/koap/Message$Option$Observe$Registration$Register : com/juul/koap/Message$Option$Observe$Registration {
 	public static final field INSTANCE Lcom/juul/koap/Message$Option$Observe$Registration$Register;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public final class com/juul/koap/Message$Option$ProxyScheme : com/juul/koap/Message$Option {

--- a/koap/src/commonMain/kotlin/Message.kt
+++ b/koap/src/commonMain/kotlin/Message.kt
@@ -303,8 +303,8 @@ sealed class Message {
              * - `1` (deregister) removes the entry from the list, if present.
              */
             sealed class Registration {
-                object Register : Registration()
-                object Deregister : Registration()
+                data object Register : Registration()
+                data object Deregister : Registration()
             }
 
             /**


### PR DESCRIPTION
Improves `toString` output, especially on JS, which currently translates to `[object Object]` (rather than `Register` or `Deregister`).