### PR TITLE
Migrate to `gradle/actions/setup-gradle`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,11 @@
 name: CI
 on:
   pull_request:
+  # Trigger on merges to `main` to allow `actions/setup-gradle` runs to write their caches.
+  # https://github.com/gradle/actions/blob/main/docs/setup-gradle.md#using-the-cache-read-only
+  push:
+    branches:
+      - main
 
 jobs:
   build:
@@ -12,38 +17,11 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '11'
-      - uses: actions/cache@v4
+      - uses: gradle/actions/setup-gradle@v3
         with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-            ~/.konan
-          key: ${{ runner.os }}-build-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
+          validate-wrappers: true
 
       - run: ./gradlew check jacocoTestReport
-      - run: ./gradlew assembleGitHubPages
-
-      - run: |
-          set -o xtrace
-          if [ ! -z "${{ secrets.SIGNING_KEY }}" ]; then
-            ./gradlew \
-            -PVERSION_NAME="unspecified" \
-            -PsigningInMemoryKey="${{ secrets.SIGNING_KEY }}" \
-            -PsigningInMemoryKeyPassword="${{ secrets.SIGNING_PASSWORD }}" \
-            publishToMavenLocal
-          else
-            ./gradlew \
-            -PVERSION_NAME="unspecified" \
-            -PRELEASE_SIGNING_ENABLED=false \
-            publishToMavenLocal
-          fi
-        if: ${{ runner.os == 'macOS' && github.repository_owner == 'JuulLabs' }}
-
       - uses: codecov/codecov-action@v4
-
-      - run: |
-          rm -f ~/.gradle/caches/modules-2/modules-2.lock
-          rm -f ~/.gradle/caches/modules-2/gc.properties
+      - run: ./gradlew assembleGitHubPages
+      - run: ./gradlew -PRELEASE_SIGNING_ENABLED=false publishToMavenLocal

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -4,9 +4,6 @@ on:
     branches:
       - main
 
-env:
-  GRADLE_OPTS: "-Dorg.gradle.daemon=false"
-
 jobs:
   deploy:
     runs-on: ubuntu-22.04
@@ -16,20 +13,11 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '11'
-
-      - uses: actions/cache@v4
+      - uses: gradle/actions/setup-gradle@v3
         with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-            ~/.konan
-          key: ${{ runner.os }}-gh-pages-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gh-pages-
-            ${{ runner.os }}-
+          validate-wrappers: true
 
       - run: ./gradlew assembleGitHubPages
-
       - uses: JamesIves/github-pages-deploy-action@v4
         with:
           folder: build/gh-pages

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,17 +14,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '11'
-
-      - uses: actions/cache@v4
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-            ~/.konan
-          key: ${{ runner.os }}-publish-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-publish-
-            ${{ runner.os }}-
+      - uses: gradle/actions/setup-gradle@v3
 
       - run: ./gradlew check
       - run: >-
@@ -35,7 +25,3 @@ jobs:
           -PmavenCentralUsername="${{ secrets.OSS_SONATYPE_NEXUS_USERNAME }}"
           -PmavenCentralPassword="${{ secrets.OSS_SONATYPE_NEXUS_PASSWORD }}"
           publish
-
-      - run: |
-          rm -f ~/.gradle/caches/modules-2/modules-2.lock
-          rm -f ~/.gradle/caches/modules-2/gc.properties

--- a/.github/workflows/signing.yml
+++ b/.github/workflows/signing.yml
@@ -1,0 +1,27 @@
+name: Validate Maven Signing
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  signing:
+    if: github.repository_owner == 'JuulLabs'
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: gradle/wrapper-validation-action@v2
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+      - uses: gradle/actions/setup-gradle@v3
+        with:
+          cache-read-only: true
+          validate-wrappers: true
+
+      - run: >
+          ./gradlew
+          -PsigningInMemoryKey=${{ secrets.SIGNING_KEY }}
+          -PsigningInMemoryKeyPassword=${{ secrets.SIGNING_PASSWORD }}
+          publishToMavenLocal


### PR DESCRIPTION
The currently used [`gradle/gradle-build-action`](https://github.com/gradle/gradle-build-action/blob/main/README.md) is deprecated in favor of [`gradle/actions/setup-gradle`](https://github.com/gradle/actions/blob/main/docs/setup-gradle.md).