### PR TITLE
Quote signing arguments

### DIFF
--- a/.github/workflows/signing.yml
+++ b/.github/workflows/signing.yml
@@ -22,6 +22,6 @@ jobs:
 
       - run: >
           ./gradlew
-          -PsigningInMemoryKey=${{ secrets.SIGNING_KEY }}
-          -PsigningInMemoryKeyPassword=${{ secrets.SIGNING_PASSWORD }}
+          -PsigningInMemoryKey="${{ secrets.SIGNING_KEY }}"
+          -PsigningInMemoryKeyPassword="${{ secrets.SIGNING_PASSWORD }}"
           publishToMavenLocal


### PR DESCRIPTION
Quotes the key name and password so they aren't interpreted by the shell.

Resolves the following issue seen during [Validate Maven Signing run](https://github.com/JuulLabs/koap/actions/runs/8898640361/job/24436223208):

```
Run ./gradlew -PsigningInMemoryKey=*** -PsigningInMemoryKeyPassword=*** publishToMavenLocal
/Users/runner/work/_temp/4518ba2a-6573-47a1-80d6-5e076c328737.sh: line 1: <redacted>: No such file or directory
Error: Process completed with exit code 1.
```