### PR TITLE
Update Gradle documentation w/ new Maven coordinate

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ repositories {
 }
 
 dependencies {
-    implementation("com.juul.koap:koap:$version")
+    implementation("com.juul.koap:koap-core:$version")
 }
 ```
 


### PR DESCRIPTION
Small change (update documentation to reflect new Maven coordinates) that was missed in #278.

Rendered markdown [here](https://github.com/JuulLabs/koap/tree/twyatt/doc/maven?tab=readme-ov-file#gradle).