### PR TITLE
Remove superfluous `setup-gradle` option

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,6 @@ jobs:
           distribution: 'temurin'
           java-version: '11'
       - uses: gradle/actions/setup-gradle@v4
-        with:
-          validate-wrappers: true
 
       - run: ./gradlew check jacocoTestReport
       - uses: codecov/codecov-action@v4

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -16,7 +16,6 @@ jobs:
       - uses: gradle/actions/setup-gradle@v4
         with:
           cache-read-only: true
-          validate-wrappers: true
 
       - run: ./gradlew assembleGitHubPages
       - run: >

--- a/.github/workflows/signing.yml
+++ b/.github/workflows/signing.yml
@@ -18,7 +18,6 @@ jobs:
       - uses: gradle/actions/setup-gradle@v4
         with:
           cache-read-only: true
-          validate-wrappers: true
 
       - run: >
           ./gradlew


### PR DESCRIPTION
Per [v4.0.0](https://github.com/gradle/actions/releases/tag/v4.0.0) release notes:

> wrapper validation has been significantly improved, and is now enabled by default