### PR TITLE
Integrate Kover for code coverage reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
           java-version: '11'
       - uses: gradle/actions/setup-gradle@v4
 
-      - run: ./gradlew check jacocoTestReport
+      - run: ./gradlew check koverXmlReport
       - uses: codecov/codecov-action@v5
       - run: ./gradlew assembleGitHubPages
       - run: ./gradlew -PRELEASE_SIGNING_ENABLED=false publishToMavenLocal

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,6 +12,7 @@ plugins {
     alias(libs.plugins.maven.publish) apply false
     alias(libs.plugins.dokka)
     alias(libs.plugins.api)
+    alias(libs.plugins.kover)
 }
 
 allprojects {
@@ -31,48 +32,12 @@ allprojects {
             showCauses = true
         }
     }
-
-    withPluginWhenEvaluated("jacoco") {
-        tasks.withType<JacocoReport> {
-            group = "Verification"
-            description = "Generate JaCoCo test coverage report"
-
-            reports {
-                csv.required.set(false)
-                html.required.set(true)
-                xml.required.set(true)
-            }
-
-            classDirectories.setFrom(layout.buildDirectory.file("classes/kotlin/jvm"))
-            sourceDirectories.setFrom(layout.projectDirectory.files("src/commonMain", "src/jvmMain"))
-            executionData.setFrom(layout.buildDirectory.file("jacoco/jvmTest.exec"))
-
-            dependsOn("jvmTest")
-        }
-
-        configure<JacocoPluginExtension> {
-            toolVersion = libs.versions.jacoco.get()
-        }
-    }
 }
 
 apiValidation {
     @OptIn(kotlinx.validation.ExperimentalBCVApi::class)
     klib {
         enabled = true
-    }
-}
-
-fun Project.withPluginWhenEvaluated(plugin: String, action: Project.() -> Unit) {
-    pluginManager.withPlugin(plugin) { whenEvaluated(action) }
-}
-
-// `afterEvaluate` does nothing when the project is already in executed state, so we need a special check for this case.
-fun <T> Project.whenEvaluated(action: Project.() -> T) {
-    if (state.executed) {
-        action()
-    } else {
-        afterEvaluate { action() }
     }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,4 @@
 [versions]
-jacoco = "0.8.7"
 kotlin = "2.1.20-Beta2"
 okio = "3.10.2"
 
@@ -17,4 +16,5 @@ kotlin-js = { id = "org.jetbrains.kotlin.js", version.ref = "kotlin" }
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 kotlinter = { id = "org.jmailen.kotlinter", version = "5.0.1" }
 kotlinx-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+kover = { id = "org.jetbrains.kotlinx.kover", version = "0.9.1" }
 maven-publish = { id = "com.vanniktech.maven.publish", version = "0.30.0" }

--- a/koap-core/build.gradle.kts
+++ b/koap-core/build.gradle.kts
@@ -2,9 +2,8 @@ plugins {
     kotlin("multiplatform")
     id("org.jetbrains.dokka")
     id("org.jmailen.kotlinter")
-    java // Needed by JaCoCo for multiplatform projects.
-    jacoco
     id("com.vanniktech.maven.publish")
+    alias(libs.plugins.kover)
 }
 
 kotlin {


### PR DESCRIPTION
"Replaces" JaCoCo with [Kover]. Although [Kover] can use JaCoCo under-the-hood, it is much simpler to configure than JaCoCo, and in newer versions of Kotlin, JaCoCo will become much more difficult to setup directly (since [`java` plugin is no longer allowed](https://github.com/JuulLabs/koap/actions/runs/13467076524/job/37634944057?pr=323) to be used) — this will unblock #323.

[Kover]: https://github.com/Kotlin/kotlinx-kover