### PR TITLE
Add iosSimulatorArm64 target to build.gradle.kts

### DIFF
--- a/koap-core/api/koap-core.klib.api
+++ b/koap-core/api/koap-core.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, js, macosArm64, macosX64, wasmJs]
+// Targets: [iosArm64, iosSimulatorArm64, js, macosArm64, macosX64, wasmJs]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/koap-core/build.gradle.kts
+++ b/koap-core/build.gradle.kts
@@ -22,6 +22,7 @@ kotlin {
     macosX64()
     macosArm64()
     iosArm64()
+    iosSimulatorArm64()
 
     sourceSets {
         commonMain.dependencies {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Additive Gradle target only; no runtime or API behavior changes.
> 
> **Overview**
> Adds **`iosSimulatorArm64()`** to the Kotlin Multiplatform targets in `koap-core/build.gradle.kts`, alongside the existing **`iosArm64()`** device target.
> 
> This lets the library compile and run on the **Apple Silicon iOS Simulator** without changing source sets or dependencies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db0ed3ec8607eba28b759980181ab483c9a90826. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->